### PR TITLE
Introduced the ExtendedContext

### DIFF
--- a/blighty/x11/canvas.py
+++ b/blighty/x11/canvas.py
@@ -22,8 +22,35 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from cairo import Context
 from blighty._x11 import BaseCanvas
 
 
+class ExtendedContext():
+    def __init__(self, ctx, methods):
+        self._ctx = ctx
+        for name, method in methods.items():
+            setattr(self, name, method.__get__(ctx, Context))
+
+    def __getattr__(self, name):
+        return getattr(self._ctx, name)
+
+
 class Canvas(BaseCanvas):
-    pass
+    def __init__(self, *args, **kwargs):
+        self._draw_methods = {}
+        self._extended_context = None
+
+        for m in [dm for dm in dir(self) if callable(getattr(self, dm)) and dm[:5] == "draw_"]:
+            self._draw_methods[m] = getattr(type(self), m)
+            delattr(type(self), m)
+
+    def _on_draw(self, ctx):
+        # Enrich the cairo context with the draw_methods
+        if self._extended_context is None:
+            self._extended_context = ExtendedContext(ctx, self._draw_methods)
+
+        self.on_draw(self._extended_context)
+
+    def on_draw(self, ctx):
+        NotImplementedError("on_draw method not implemented in subclass.")

--- a/tests/test_x11_canvas.py
+++ b/tests/test_x11_canvas.py
@@ -22,19 +22,23 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import blighty.x11 as x11
+from blighty import CanvasGravity
+
+from random import random as r
+
+
 def test_canvas():
-    import blighty.x11 as x11
-    from blighty import CanvasGravity
 
     class MyCanvas(x11.Canvas):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
 
             self.r = 50.0
-            self.d = 1.0
+            self.d = 2.0
 
         def on_button_pressed(self, button, state, x, y):
-            if button == 1 and state == 0:
+            if button == 1 and state == 16:
                 self.destroy()
 
         def on_key_pressed(self, keysym, state):
@@ -43,7 +47,7 @@ def test_canvas():
 
         def on_draw(self, cr):
             cr.set_line_width(8)
-            cr.set_source_rgba(0.7, 0.2, 0.0, .5)
+            cr.set_source_rgba(*[r() for _ in range(4)])
 
             w, h = self.get_size()
 
@@ -71,5 +75,38 @@ def test_canvas():
     assert x11.start_event_loop() is None
 
 
+def test_draw_methods():
+
+    class DrawMethodsCanvas(x11.Canvas):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+            self.c = 0
+
+        def on_button_pressed(self, button, state, x, y):
+            if button == 1:
+                self.destroy()
+
+        def draw_rect(ctx, width, height):
+            ctx.set_source_rgb(*[r() for _ in range(3)])
+            ctx.rectangle(0, 0, width, height)
+            ctx.fill()
+
+        def on_draw(self, ctx):
+            if self.c > 2:
+                self.dispose()
+                return
+
+            for i in range(4):
+                ctx.draw_rect(self.width >> i, self.height >> i)
+
+            self.c += 1
+
+    canvas = DrawMethodsCanvas(40, 40, 128, 128, interval = 1000)
+    canvas.show()
+    x11.start_event_loop()
+
+
 if __name__ == "__main__":
     test_canvas()
+    test_draw_methods()


### PR DESCRIPTION
Methods of subclasses of the `Canvas` class that start with the `draw_` prefix will be re-bound to the cairo context passed to the `on_draw` callback method. For example,

~~~ python
class DrawMethodsCanvas(x11.Canvas):
    def on_button_pressed(self, button, state, x, y):
        if button == 1:
            self.destroy()

    def draw_rect(ctx, width, height):
        ctx.set_source_rgb(*[r() for _ in range(3)])
        ctx.rectangle(0, 0, width, height)
        ctx.fill()

    def on_draw(self, ctx):
        for i in range(4):
            ctx.draw_rect(self.width >> i, self.height >> i)
~~~

Whilst the method `draw_rect` is defined inside the `DrawMethodsCanvas` class, inside the `on_draw` method it can be accessible as a method of `ctx` (which is now an instance of `ExtendedContext`, a wrapper around `cairo.Context`).